### PR TITLE
Version bump to v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.0 (26-12-2019)
+  * Upgraded template-haskell bounds to support GHC >=8.6.5
+  * Fixed ReturnA pattern synonym due to haskell-src-exts API changes.
+  * Added newtype-deriving Semigroup for 'Tuple'.
+  * Changed 'arrowp-ext' excutable name to simply 'arrowp'.
 # 0.2.2 (25-08-2017)
   * Expose a quasi quoter that accepts a 'ParseMode' (fixity, extensions, etc.) 
 # 0.2.1.1 (25-08-2017)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Arrowp-qq
 A preprocessor for arrow notation 
 based on the arrowp preprocessor developed by Ross Paterson <ross@soi.city.ac.uk>.
 
+Forked from Jose Iborra's arrowp-qq preprocessor, updating package version constraints and fixing resulting code breakage. It should now build under Cabal v3.
+
 Notable features include support for GHC Haskell syntax and a
 quasiquoter that can be used instead of the preprocessor.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Arrowp-qq
 A preprocessor for arrow notation 
 based on the arrowp preprocessor developed by Ross Paterson <ross@soi.city.ac.uk>.
 
-Forked from Jose Iborra's arrowp-qq preprocessor, updating package version constraints and fixing resulting code breakage. It should now build under Cabal v3.
 
 Notable features include support for GHC Haskell syntax and a
 quasiquoter that can be used instead of the preprocessor.

--- a/arrowp-qq.cabal
+++ b/arrowp-qq.cabal
@@ -1,11 +1,11 @@
 Name:           arrowp-qq
-Version:        0.2.2
+Version:        0.3.0
 Cabal-Version:  >= 1.20
 Build-Type:     Simple
 License:        GPL
 License-File:   LICENCE
 Author:         Jose Iborra <pepeiborra@gmail.com>
-Maintainer:     Jose Iborra <pepeiborra@gmail.com>
+Maintainer:     John 'Ski <N/A>
 Homepage:       https://github.com/pepeiborra/arrowp
 Category:       Development
 Synopsis:       A preprocessor and quasiquoter for translating arrow notation
@@ -36,7 +36,7 @@ Library
                    haskell-src-exts,
                    haskell-src-exts-util >= 0.2.0,
                    haskell-src-meta,
-                   template-haskell < 2.13, 
+                   template-haskell >= 2.14, 
                    transformers,
                    uniplate
     if flag(Debug)
@@ -49,7 +49,7 @@ Library
     Other-Modules:  ArrCode ArrSyn NewCode SrcLocs Utils
     Default-Language:    Haskell2010
 
-executable arrowp-ext
+executable arrowp
   buildable: True
   main-is: Main.hs
   hs-source-dirs:

--- a/arrowp-qq.cabal
+++ b/arrowp-qq.cabal
@@ -36,7 +36,7 @@ Library
                    haskell-src-exts,
                    haskell-src-exts-util >= 0.2.0,
                    haskell-src-meta,
-                   template-haskell >= 2.14, 
+                   template-haskell, 
                    transformers,
                    uniplate
     if flag(Debug)

--- a/src/ArrCode.hs
+++ b/src/ArrCode.hs
@@ -187,7 +187,7 @@ toHaskell = rebracket1 . toHaskellCode . code
     toHaskellArg = Paren def . toHaskellCode
 
 newtype Tuple = Tuple (Set (Name ()))
-  deriving (Eq,Generic,Monoid,Show)
+  deriving (Eq,Generic,Semigroup,Monoid,Show)
 instance Observable Tuple
 
 isEmptyTuple :: Tuple -> Bool

--- a/src/NewCode.hs
+++ b/src/NewCode.hs
@@ -34,7 +34,7 @@ getLoc :: Code -> S
 getLoc (Loc s) = s
 getLoc other   = error $ "getLoc: " ++ show other
 
-pattern ReturnA l = ExprHole (ReturnCode l)
+pattern ReturnA l = Var OpCode (Special OpCode (ExprHole (ReturnCode l)))
 pattern Arr l i pat bb e = Lambda (ArrCode l i bb) [pat] e
 pattern Compose a bb c <- List ComposeCode ( split -> (a,bb,c) )
   where


### PR DESCRIPTION
Fixed build issues under Cabal v3 / Stack. All specific changes are noted in the my fork's changelog. 

Additionally, the `arrowp-ext` executable name was changed back to `arrowp` for simplicity's sake. I assume people would have no reason to install both the original and this upgraded fork, so name collision shouldn't be an issue.